### PR TITLE
Don't run on every single https:// page!

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "name"                      : "Mint Date Range",
     "short_name"                : "MintDateRange",
-    "version"                   : "0.4.9",
+    "version"                   : "0.5",
     "manifest_version"          : 2,
     "description"               : "Choose a date range for Mint's transaction list",
     "background": {
@@ -16,7 +16,7 @@
     "content_scripts": 
     [
         {
-            "matches"           : ["https://*/*"],
+            "matches"           : ["https://*.mint.com/*"],
             "css"               : ["css/main.css"],
             "js"                : [
                                     "js/jquery.min.js", 


### PR DESCRIPTION
Currently this extension injects a Google Analytics script, CSS, and jQuery, glDatePicker, and the MDR scripts into **every single https:// page the user visits**.

This pull request restricts the extension to all https:// pages of all subdomains of mint.com and updates the version to 0.5.
